### PR TITLE
Add GitHub release job after successful image build

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -43,3 +43,14 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  release:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- Adds a `release` job to `release-image.yml` that runs after `build-and-push` succeeds on a tag push
- Uses `softprops/action-gh-release@v2` with `generate_release_notes: true` to auto-create a GitHub release for the tag

## Test plan
- [x] Validated workflow YAML parses correctly
- [ ] Confirm the release job runs and creates a release on the next `v*` tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNobrxTmoo9JfAqKwAbxk7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNobrxTmoo9JfAqKwAbxk7)_