### PR TITLE
Add GitHub release job after successful image build

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -43,3 +43,14 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  release:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
Runs after build-and-push on tag push; softprops/action-gh-release auto-generates release notes, no extra config needed.


Claude-Session: https://claude.ai/code/session_01DNobrxTmoo9JfAqKwAbxk7