### PR TITLE
Dedupe test setup() to go through migrate() instead of raw SCHEMA

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -613,8 +613,17 @@ mod tests {
     fn setup() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
-        conn.execute_batch(SCHEMA).unwrap();
+        migrate(&conn);
         conn
+    }
+
+    #[test]
+    fn setup_applies_schema_through_migrate() {
+        let conn = setup();
+        let user_version: i64 = conn
+            .query_row("PRAGMA user_version;", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(user_version, 2, "setup() must apply schema via migrate(), not duplicate SCHEMA directly");
     }
 
     #[test]


### PR DESCRIPTION
setup() and migrate() applied the same SCHEMA constant through two
separate code paths; setup() now reuses migrate() like test_db()
already does. Added a test asserting user_version == 2 after setup()
to pin the equivalence.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PxP37hzVzorMQfUDPZbP6M